### PR TITLE
Add site.baseurl in tags containing a link to the site.

### DIFF
--- a/feed.articles.xml
+++ b/feed.articles.xml
@@ -6,14 +6,14 @@ layout: rss-feed
 	<channel>
 		<title>{{ site.name }} - Articles</title>
 		<description>{{ site.description }}</description>
-		<link>{{ site.url }}</link>
+		<link>{{ site.url }}{{ site.baseurl }}</link>
 		{% for post in site.posts %}
 			{% unless post.link %}
 			<item>
 				<title>{{ post.title }}</title>
 				<description>{{ post.content | xml_escape }}</description>
 				<published>{{ post.date }}</published>
-				<link>{{ site.url }}{{ post.url }}</link>
+				<link>{{ site.url }}{{ site.baseurl }}{{ post.url }}</link>
 			</item>
 			{% endunless %}
 		{% endfor %}

--- a/feed.category.xml
+++ b/feed.category.xml
@@ -6,13 +6,13 @@ layout: rss-feed
 	<channel>
 		<title>{{ site.name }} - Miscellaneous</title>
 		<description>Posts categorized as 'miscellaneous'</description>
-		<link>{{ site.url }}</link>
+		<link>{{ site.url }}{{ site.baseurl }}</link>
 		{% for post in site.categories.miscellaneous limit:10 %}
 			<item>
 				<title>{{ post.title }}</title>
 				<description>{{ post.content | xml_escape }}</description>
 				<published>{{ post.date }}</published>
-				<link>{{ site.url }}{{ post.url }}</link>
+				<link>{{ site.url }}{{ site.baseurl }}{{ post.url }}</link>
 			</item>
 		{% endfor %}
 	</channel>

--- a/feed.links.xml
+++ b/feed.links.xml
@@ -6,7 +6,7 @@ layout: rss-feed
 	<channel>
 		<title>{{ site.name }} - Links</title>
 		<description>{{ site.description }}</description>
-		<link>{{ site.url }}</link>
+		<link>{{ site.url }}{{ site.baseurl }}</link>
 		{% for post in site.posts %}
 			{% if post.link %}
 			<item>

--- a/feed.xml
+++ b/feed.xml
@@ -6,13 +6,13 @@ layout: rss-feed
 	<channel>
 		<title>{{ site.name }}</title>
 		<description>{{ site.description }}</description>
-		<link>{{ site.url }}</link>
+		<link>{{ site.url }}{{ site.baseurl }}</link>
 		{% for post in site.posts limit:10 %}
 			<item>
 				<title>{{ post.title }}</title>
 				<description>{{ post.content | xml_escape }}</description>
 				<published>{{ post.date }}</published>
-				<link>{{ site.url }}{{ post.url }}</link>
+				<link>{{ site.url }}{{ site.baseurl }}{{ post.url }}</link>
 			</item>
 		{% endfor %}
 	</channel>


### PR DESCRIPTION
Should only affect users that have site.baseurl defined in _config.yml. Without it, the URLs are not valid.

I didn't add site.baseurl in [feed.links.xml line 16](https://github.com/snaptortoise/jekyll-rss-feeds/blob/master/feed.links.xml#L16), because I do not have that set up for my blog and was not sure if there was a reason it was escaped or not.
