### PR TITLE
If a post has a description, use it in the XML data

### DIFF
--- a/feed.articles.xml
+++ b/feed.articles.xml
@@ -13,10 +13,8 @@
 				<title>{{ post.title | xml_escape }}</title>
 				{% if post.excerpt %}
 					<description>{{ post.excerpt | xml_escape }}</description>
-				{% elsif post.description %}
-					<description>{{ post.content | xml_escape }}</description>
 				{% else %}
-					<description>{{ site.description | xml_escape }}</description>
+					<description>{{ post.content | xml_escape }}</description>
 				{% endif %}
 				<pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
 				<link>{{ site.url }}{{ post.url }}</link>

--- a/feed.category.xml
+++ b/feed.category.xml
@@ -12,10 +12,8 @@
 				<title>{{ post.title | xml_escape }}</title>
 				{% if post.excerpt %}
 					<description>{{ post.excerpt | xml_escape }}</description>
-				{% elsif post.description %}
-					<description>{{ post.content | xml_escape }}</description>
 				{% else %}
-					<description>{{ site.description | xml_escape }}</description>
+					<description>{{ post.content | xml_escape }}</description>
 				{% endif %}
 				<pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
 				<link>{{ site.url }}{{ post.url }}</link>

--- a/feed.links.xml
+++ b/feed.links.xml
@@ -13,10 +13,8 @@
 				<title>{{ post.title | xml_escape }}</title>
 				{% if post.excerpt %}
 					<description>{{ post.excerpt | xml_escape }}</description>
-				{% elsif post.description %}
-					<description>{{ post.content | xml_escape }}</description>
 				{% else %}
-					<description>{{ site.description | xml_escape }}</description>
+					<description>{{ post.content | xml_escape }}</description>
 				{% endif %}
 				<pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
 				<link>{{ post.link | escape }}</link>

--- a/feed.xml
+++ b/feed.xml
@@ -12,10 +12,8 @@
 				<title>{{ post.title | xml_escape }}</title>
 				{% if post.excerpt %}
 					<description>{{ post.excerpt | xml_escape }}</description>
-				{% elsif post.description %}
-					<description>{{ post.content | xml_escape }}</description>
 				{% else %}
-					<description>{{ site.description | xml_escape }}</description>
+					<description>{{ post.content | xml_escape }}</description>
 				{% endif %}
                         	<pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
 				<link>{{ site.url }}{{ post.url }}</link>


### PR DESCRIPTION
I noticed that the system was putting the entire post body in the description.  It is more desirable to place just the description of the post in there.  You can now add the description: yaml markup to your posts to have a more clean feed XML.  Alternatively, if you do not specify a post description, the page title will be used (instead of the post body).
