### PR TITLE
clarified explanation of frontmatter content in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,6 @@ This makes it easy to reference the title, description and URL for your site in 
 
 Miscellany
 -----------
-- **Note on YAML Front Matter block**: The xml files contain a [YAML Front Matter](https://github.com/mojombo/jekyll/wiki/YAML-Front-Matter) block with the line <code>layout: none</code>. This is necessary because Jekyll will not process a page with Liquid unless there is a YAML block at the top of the file.
+- **Note on YAML Front Matter block**: The xml files contain an empty [YAML Front Matter](https://github.com/mojombo/jekyll/wiki/YAML-Front-Matter) block. This is necessary because Jekyll will not process a page with Liquid unless there is a YAML block at the top of the file. Previously, this block contained the line <code>layout: none</code> but that was found to cause a separate issue for some: https://github.com/snaptortoise/jekyll-rss-feeds/commit/209b83b504fde14722491ea5d9753189566c8598
 - **RSS Autodiscovery**: If your template is not already setup to do so, make sure the RSS feeds are discoverable by browsers, bots, etc: [rssboard.org/rss-autodiscovery](http://www.rssboard.org/rss-autodiscovery)
 - **Validation**: You can use the W3C Validator to make sure your feeds are formatted correctly: [http://validator.w3.org/feed/](http://validator.w3.org/feed/)


### PR DESCRIPTION
The `layout: none` code was removed from the files but the docs indicated it was still there. Small, small change.