### PR TITLE
Added: 'layout:' to frontmatter

### DIFF
--- a/feed.category.xml
+++ b/feed.category.xml
@@ -1,4 +1,5 @@
 ---
+layout:
 ---
 <?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">


### PR DESCRIPTION
On Jekyll 2.5.3 running OSX 10.10.2, Jekyll was adding the default.html layout to the xml. Adding this fixed the issue.