### PR TITLE
Don't hardcode filename in self-reference

### DIFF
--- a/feed.articles.xml
+++ b/feed.articles.xml
@@ -6,7 +6,7 @@
 		<title>{{ site.name | xml_escape }} - Articles</title>
 		<description>{% if site.description %}{{ site.description | xml_escape }}{% endif %}</description>
 		<link>{{ site.url }}</link>
-		<atom:link href="{{ site.url }}/feed.articles.xml" rel="self" type="application/rss+xml" />
+		<atom:link href="{{ site.url }}/{{ page.path }}" rel="self" type="application/rss+xml" />
 		{% for post in site.posts %}
 			{% unless post.link %}
 			<item>

--- a/feed.category.xml
+++ b/feed.category.xml
@@ -6,7 +6,7 @@
 		<title>{{ site.name | xml_escape }} - Miscellaneous</title>
 		<description>Posts categorized as 'miscellaneous'</description>
 		<link>{{ site.url }}</link>
-		<atom:link href="{{ site.url }}/feed.category.xml" rel="self" type="application/rss+xml" />
+		<atom:link href="{{ site.url }}/{{ page.path }}" rel="self" type="application/rss+xml" />
 		{% for post in site.categories.miscellaneous limit:10 %}
 			<item>
 				<title>{{ post.title | xml_escape }}</title>

--- a/feed.links.xml
+++ b/feed.links.xml
@@ -6,7 +6,7 @@
 		<title>{{ site.name | xml_escape }} - Links</title>
 		<description>{% if site.description %}{{ site.description | xml_escape }}{% endif %}</description>
 		<link>{{ site.url }}</link>
-		<atom:link href="{{ site.url }}/feed.links.xml" rel="self" type="application/rss+xml" />
+		<atom:link href="{{ site.url }}/{{ page.path }}" rel="self" type="application/rss+xml" />
 		{% for post in site.posts %}
 			{% if post.link %}
 			<item>

--- a/feed.xml
+++ b/feed.xml
@@ -6,7 +6,7 @@
 		<title>{{ site.name | xml_escape }}</title>
 		<description>{% if site.description %}{{ site.description | xml_escape }}{% endif %}</description>		
 		<link>{{ site.url }}</link>
-		<atom:link href="{{ site.url }}/feed.xml" rel="self" type="application/rss+xml" />
+		<atom:link href="{{ site.url }}/{{ page.path }}" rel="self" type="application/rss+xml" />
 		{% for post in site.posts limit:10 %}
 			<item>
 				<title>{{ post.title | xml_escape }}</title>


### PR DESCRIPTION
This allows the files to be renamed, for example to replace an existing
feed at a given location.