### PR TITLE
Add syndication module to provide easy configuration for update hints.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,13 @@ These templates rely on a customized version of <code>\_config.yml</code>.  The 
 	name: Your Blog's Name
 	description: A description for your blog
 	url: http://your-blog-url.example.com
+	feed_items: 10
+	feed_update_period: daily
+	feed_update_frequency: 1
 
 This makes it easy to reference the title, description and URL for your site in the feed templates using <code>{{ site.name }}</code>, <code>{{ site.description }}</code> and <code>{{ site.url }}</code>.  Even if you're not using these feed templates, you might find these variables useful when you're designing your layouts.
 
+The `feed_*` items shown above are the default. You can safely omit them.
 
 Miscellany
 -----------

--- a/feed.articles.xml
+++ b/feed.articles.xml
@@ -1,10 +1,15 @@
 ---
 ---
 <?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+<rss version="2.0"
+	xmlns:atom="http://www.w3.org/2005/Atom"
+	xmlns:sy="http://purl.org/rss/1.0/modules/syndication/"
+>
 	<channel>
 		<title>{{ site.name | xml_escape }} - Articles</title>
 		<description>{% if site.description %}{{ site.description | xml_escape }}{% endif %}</description>
+		<sy:updatePeriod>{{ site.feed_update_period | default: "daily" | xml_escape }}</sy:updatePeriod>
+		<sy:updateFrequency>{{ site.feed_update_frequency | default: 1 | xml_escape }}</sy:updateFrequency>
 		<link>{{ site.url }}</link>
 		<atom:link href="{{ site.url }}/{{ page.path }}" rel="self" type="application/rss+xml" />
 		<lastBuildDate>{% for post in site.posts limit:1 %}{% unless post.link %}{{ post.date | date_to_rfc822 }}{% endunless %}{% endfor %}</lastBuildDate>

--- a/feed.category.xml
+++ b/feed.category.xml
@@ -1,14 +1,20 @@
 ---
 ---
 <?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+<rss version="2.0"
+	xmlns:atom="http://www.w3.org/2005/Atom"
+	xmlns:sy="http://purl.org/rss/1.0/modules/syndication/"
+>
 	<channel>
 		<title>{{ site.name | xml_escape }} - Miscellaneous</title>
 		<description>Posts categorized as 'miscellaneous'</description>
+		<sy:updatePeriod>{{ site.feed_update_period | default: "daily" | xml_escape }}</sy:updatePeriod>
+		<sy:updateFrequency>{{ site.feed_update_frequency | default: 1 | xml_escape }}</sy:updateFrequency>
 		<link>{{ site.url }}</link>
 		<atom:link href="{{ site.url }}/{{ page.path }}" rel="self" type="application/rss+xml" />
 		<lastBuildDate>{% for post in site.categories.miscellaneous limit:1 %}{{ post.date | date_to_rfc822 }}{% endfor %}</lastBuildDate>
-		{% for post in site.categories.miscellaneous limit:10 %}
+		{% assign feed_items = site.feed_items | default: 10 %}
+		{% for post in site.categories.miscellaneous limit:feed_items %}
 			<item>
 				<title>{{ post.title | xml_escape }}</title>
 				{% if post.excerpt %}

--- a/feed.links.xml
+++ b/feed.links.xml
@@ -1,10 +1,15 @@
 ---
 ---
 <?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+<rss version="2.0"
+	xmlns:atom="http://www.w3.org/2005/Atom"
+	xmlns:sy="http://purl.org/rss/1.0/modules/syndication/"
+>
 	<channel>
 		<title>{{ site.name | xml_escape }} - Links</title>
 		<description>{% if site.description %}{{ site.description | xml_escape }}{% endif %}</description>
+		<sy:updatePeriod>{{ site.feed_update_period | default: "daily" | xml_escape }}</sy:updatePeriod>
+		<sy:updateFrequency>{{ site.feed_update_frequency | default: 1 | xml_escape }}</sy:updateFrequency>
 		<link>{{ site.url }}</link>
 		<atom:link href="{{ site.url }}/{{ page.path }}" rel="self" type="application/rss+xml" />
 		<lastBuildDate>{% for post in site.posts limit:1 %}{% if post.link %}{{ post.date | date_to_rfc822 }}{% ifunless %}{% endfor %}</lastBuildDate>

--- a/feed.xml
+++ b/feed.xml
@@ -1,19 +1,26 @@
 ---
 ---
 <?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
+<rss version="2.0"
+	xmlns:atom="http://www.w3.org/2005/Atom"
+	xmlns:dc="http://purl.org/dc/elements/1.1/"
+	xmlns:sy="http://purl.org/rss/1.0/modules/syndication/"
+>
 	<channel>
 		<title>{{ site.name | xml_escape }}</title>
 		<description>{% if site.description %}{{ site.description | xml_escape }}{% endif %}</description>		
+		<sy:updatePeriod>{{ site.feed_update_period | default: "daily" | xml_escape }}</sy:updatePeriod>
+		<sy:updateFrequency>{{ site.feed_update_frequency | default: 1 | xml_escape }}</sy:updateFrequency>
 		<link>{{ site.url }}</link>
 		<atom:link href="{{ site.url }}/{{ page.path }}" rel="self" type="application/rss+xml" />
 		<lastBuildDate>{% for post in site.posts limit:1 %}{{ post.date | date_to_rfc822 }}{% endfor %}</lastBuildDate>
-		{% for post in site.posts limit:10 %}
+		{% assign feed_items = site.feed_items | default: 10 %}
+		{% for post in site.posts limit:feed_items %}
 			<item>
 				<title>{{ post.title | xml_escape }}</title>
 				{% if post.author.name %}
 					<dc:creator>{{ post.author.name | xml_escape }}</dc:creator>
-				{% endif %}        
+				{% endif %}
 				{% if post.excerpt %}
 					<description>{{ post.excerpt | xml_escape }}</description>
 				{% else %}


### PR DESCRIPTION
This commit adds the `<sy:updatePeriod>` and `<sy:updateFrequency>` elements to all feeds. These elements are defined in the [RSS 1.0 Syndication Modules specification](http://web.resource.org/rss/1.0/modules/syndication/).

The purpose of these elements is to provide hints for automated feed consumers regarding how often to expect updates, which assists in scheduling polling times so as not to overly tax a given server.

The templates use the default values intentionally so as to avoid changing the default behavior of the feeds as-is. Configuration options have been provided to make changing the values easier, since all that's needed is an edit to `_config.yml`.